### PR TITLE
アクセス制限機能を追加

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,5 @@
 class QuestionsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_question, only: [:show, :edit, :update, :destroy]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [:edit, :update]
   before_action :ensure_correct_user, only: [:edit, :update]
 
   def show
@@ -19,9 +20,11 @@ class UsersController < ApplicationController
   end
 
   def ensure_correct_user
-    if current_user.id != params[:id].to_i 
-      flash[:notice] = "他のユーザーは編集できません"
-      redirect_to(root_path)
+    if current_user
+      if current_user.id != params[:id].to_i 
+        flash[:notice] = "他のユーザーは編集できません"
+        redirect_to(root_path)
+      end
     end
   end
 
@@ -29,4 +32,5 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:name, :profile_image, :self_introduciton)
   end
+  
 end

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -4,5 +4,7 @@
 <% end %>
 <%= @question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %>
 
-<%= link_to '編集する', edit_question_path %> 
-<%= link_to '削除する', question_path, method: :delete %> 
+<% if current_user %>
+  <%= link_to '編集する', edit_question_path %> 
+  <%= link_to '削除する', question_path, method: :delete %> 
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,6 @@
 <% if current_user %>
   <% if @user.id == current_user.id %>
     <%= link_to("ユーザーを編集", edit_user_path) %>
-    <%= link_to("パスワードを編集", "/users/#{@user.id}/edit/password") %>
+    <%= link_to("パスワードの変更", "/edit/password") %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resources :users, only: [:show, :edit, :update]
   
   devise_scope :user do
-    get "users/:id/edit/password", to: "devise/registrations#edit"
+    get "edit/password", to: "devise/registrations#edit"
   end
 
   resources :questions


### PR DESCRIPTION
自分以外のユーザーのプロフィール、パスワード編集機能の制限、また、ログイン後のみプロフィール編集、質問の追加、編集、削除ができるようにする。
# 関連issue
#57 