### PR TITLE
エラー、サクセスメッセージの位置を変更

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -27,8 +27,8 @@
 #questions-new, #questions-create, #questions-edit, #questions-update {
   .container {
     .error-messages {
+      text-align: center;
       padding-top: 20px;
-      padding-left: 15%;
       font-weight: bold;
       color: rgb(250, 127, 127);
       li {
@@ -67,84 +67,73 @@
 
 
 #questions-show {
-  .flash-and-error-container{
+  .notice {
     text-align: center;
-    .notice {
-      padding-top: 2%;
-      padding-right: 590px;
-      color: rgb(250, 127, 127);
-      font-weight: bold;
-    }
+    color: #fa7f7f;
+    font-weight: bold;
+    padding-top: 30px;
+  }
 
-    .error_messages {
-      padding: 10px;
-      li {
-        @extend .notice
+  .question-container {
+    width: 800px;
+    margin: 0 auto;
+    border: 2px solid #ffa6a6;
+    margin-top: 30px;
+    margin-bottom: 35px;
+    border-radius: 15px;
+    .question_user_informations {
+      display: flex;
+      text-align: left;
+      padding: 1% 0;
+      margin: 0 2%;
+      border-bottom: 2px solid #ffa6a6;
+      .question_user_profile_image {
+        border-radius: 50%;
+      }
+      .question_user_name_and_update_at {
+        padding-top: 1%;
+        padding-left: 2%;
+        li {
+          list-style: none;
+        }
       }
     }
-    .question-container {
-      width: 800px;
-      margin: 0 auto;
-      border: 2px solid #ffa6a6;
-      margin-top: 30px;
-      margin-bottom: 35px;
-      border-radius: 15px;
-      .question_user_informations {
-        display: flex;
-        text-align: left;
-        padding: 1% 0;
-        margin: 0 2%;
-        border-bottom: 2px solid #ffa6a6;
-        .question_user_profile_image {
-          border-radius: 50%;
-        }
-        .question_user_name_and_update_at {
-          padding-top: 1%;
-          padding-left: 2%;
-          li {
-            list-style: none;
-          }
-        }
+    .question-answer-informations {
+      padding: 1%;
+      margin: 0 2%;
+      border-bottom: 2px solid #ffa6a6;
+      span {
+        font-weight: bold;
+        color: #ffa6a6;
+        padding-right: 6px;
       }
-      .question-answer-informations {
+    }
+    .question_content {    
+      padding: 1%;
+      margin: 3px 2% 0 2%;
+      border-bottom: 2px solid #ffa6a6; 
+      .question_text {
         text-align: left;
-        padding: 1%;
-        margin: 0 2%;
-        border-bottom: 2px solid #ffa6a6;
-        span {
-          font-weight: bold;
+      }
+      .question_image {
+        padding-top: 7px;
+      }
+    }
+    .question_options {
+      padding: 1.2% 3%;
+      height: 23px;
+      .question_interest {
+        float: left;
+        .question-icon {
+          font-size: 21px;
           color: #ffa6a6;
-          padding-right: 6px;
         }
       }
-      .question_content {    
-        padding: 1%;
-        margin: 3px 2% 0 2%;
-        border-bottom: 2px solid #ffa6a6; 
-        .question_text {
-          text-align: left;
-        }
-        .question_image {
-          padding-top: 7px;
-        }
-      }
-      .question_options {
-        padding: 1.2% 3%;
-        height: 23px;
-        .question_interest {
-          float: left;
-          .question-icon {
-            font-size: 21px;
-            color: #ffa6a6;
-          }
-        }
-        .question_edit_and_delete {
-          float: right;
-        }
+      .question_edit_and_delete {
+        float: right;
       }
     }
   }
-  
 
   .answer-container {
     width: 800px;
@@ -201,6 +190,10 @@
   #current-answer-container {
     .current-answer-content {
       text-align: center;
+      .error_messages {
+        color: rgb(250, 127, 127);
+        font-weight: bold;
+      }
       textarea {
         width: 70%;
         font-size: 16px;

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,7 +15,7 @@ class AnswersController < ApplicationController
       flash[:notice] = "回答が追加されました"
       redirect_to question_path
     else
-      redirect_to question_path, flash:{error:@answer.errors.full_messages}
+      redirect_to question_path(anchor: "current-answer-container"), flash:{error:@answer.errors.full_messages}
     
     end
   end  

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,77 +1,66 @@
-<div class="flash-and-error-container">
-  <%= render 'layouts/flash' %>
-  <% if flash[:error].present? %>
-    <div class="error_messages">
+<%= render 'layouts/flash' %>
+
+<div class="question-container">
+  <div class="question_user_informations">  
+    <% if @question.user.profile_image.present? %>
+      <%= image_tag @question.user.profile_image.thumb65.url, class: "question_user_profile_image" %>
+    <% else %>
+      <%= image_tag "default.jpg", size: "65x65", class: "question_user_profile_image" %>
+    <% end %>
+  
+    <div class="question_user_name_and_update_at">
       <ul>
-        <% flash[:error].each do |error| %>
-          <li><%= error %></li>
-        <% end %>
-      </ul>
+        <li><%= link_to(@question.user.name, user_path(@question.user.id)) %></li>
+        <li><span>質問日時 <%= @question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></span></li>
+      </ul>      
     </div>
-  <% end %>
-
-  <div class="question-container">
-    <div class="question_user_informations">  
-      <% if @question.user.profile_image.present? %>
-        <%= image_tag @question.user.profile_image.thumb65.url, class: "question_user_profile_image" %>
-      <% else %>
-        <%= image_tag "default.jpg", size: "65x65", class: "question_user_profile_image" %>
-      <% end %>
+  </div>
     
-      <div class="question_user_name_and_update_at">
-        <ul>
-          <li><%= link_to(@question.user.name, user_path(@question.user.id)) %></li>
-          <li><span>質問日時 <%= @question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></span></li>
-        </ul>      
-      </div>
+  <div class="question-answer-informations">
+    <span><%= @answers.count %>件の回答があります</span>
+
+    <% if current_user %>
+      <%= link_to "回答する", question_path(anchor: "current-answer-container") %>
+    <% end %>
+  </div>  
+
+  <div class="question_content">
+    <div class="question_text">
+      <%= @question.question_content %>
     </div>
-     
-    <div class="question-answer-informations">
-      <span><%= @answers.count %>件の回答があります</span>
-
-      <% if current_user %>
-        <%= link_to "回答する", question_path(anchor: "current-answer-container") %>
-      <% end %>
-    </div>  
-
-    <div class="question_content">
-      <div class="question_text">
-        <%= @question.question_content %>
-      </div>
-      <div class="question_image">
-        <% if @question.question_image.present? %>
-          <%= image_tag @question.question_image.url %>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="question_options">
-      <div class="question_interest">
-        <% if current_user and Favorite.find_by(user_id:current_user.id, question_id:@question.id) %>
-          <%= link_to( "/favorites/#{@question.id}/destroy", {method: "delete"}) do %>
-            <i class="fas fa-smile question-icon"></i>
-          <% end %>
-        <% else %>
-          <%= link_to("/favorites/#{@question.id}/create", {method: "post"}) do %>
-            <i class="far fa-smile question-icon"></i>
-          <% end %>
-        <% end %>
-
-        <span><%= @favorites_count %>人が応援しています</span>
-      </div>
-
-      <% if current_user %>
-        <% if @question.user_id == current_user.id %>
-          <div class="question_edit_and_delete">
-            <%= link_to '編集する', edit_question_path %> 
-            <%= link_to '削除する', question_path, method: :delete %> 
-          </div>
-        <% end %>
+    <div class="question_image">
+      <% if @question.question_image.present? %>
+        <%= image_tag @question.question_image.url %>
       <% end %>
     </div>
+  </div>
 
+  <div class="question_options">
+    <div class="question_interest">
+      <% if current_user and Favorite.find_by(user_id:current_user.id, question_id:@question.id) %>
+        <%= link_to( "/favorites/#{@question.id}/destroy", {method: "delete"}) do %>
+          <i class="fas fa-smile question-icon"></i>
+        <% end %>
+      <% else %>
+        <%= link_to("/favorites/#{@question.id}/create", {method: "post"}) do %>
+          <i class="far fa-smile question-icon"></i>
+        <% end %>
+      <% end %>
+
+      <span><%= @favorites_count %>人が応援しています</span>
+    </div>
+
+    <% if current_user %>
+      <% if @question.user_id == current_user.id %>
+        <div class="question_edit_and_delete">
+          <%= link_to '編集する', edit_question_path %> 
+          <%= link_to '削除する', question_path, method: :delete %> 
+        </div>
+      <% end %>
+    <% end %>
   </div>
 </div>
+
 
 
 <% @answers.each do |answer| %>
@@ -128,23 +117,32 @@
 <% end %>
 
 
-  <% if current_user %>
-    <div id="current-answer-container">
-      <%= form_with model:@answer, local: true do |form| %>
-        <div class="current-answer-content">       
-          <%= form.text_area :answer_content, placeholder:"回答する", rows:16 %>
-        </div>
+<% if current_user %>
+  <div id="current-answer-container">
+    <%= form_with model:@answer, local: true do |form| %>
+      <div class="current-answer-content">       
+        <% if flash[:error].present? %>
+          <div class="error_messages">
+            <ul>
+              <% flash[:error].each do |error| %>
+                <li><%= error %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <%= form.text_area :answer_content, placeholder:"回答する", rows:16 %>
+      </div>
 
-        <div class="current-answer-image">
+      <div class="current-answer-image">
+      
+        <%= form.label :answer_image, "画像をアップロード" %>
         
-          <%= form.label :answer_image, "画像をアップロード" %>
-          
-          <%= form.file_field :answer_image %>
-        </div>
+        <%= form.file_field :answer_image %>
+      </div>
 
-        <div class="actions">
-          <%= form.submit "回答", class: "button" %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
+      <div class="actions">
+        <%= form.submit "回答", class: "button" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
質問作成ページ、質問編集ページ、質問詳細ページのエラー、サクセスメッセージの位置をページの中心に変更しました。
# 関連issue
#149 