### PR TITLE
質問詳細ページのanchorの指定先idを変更

### DIFF
--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -191,8 +191,8 @@
     }
   }
 
-  #current-answer-container {
-    .current-answer-content {
+  .current-answer-container {
+    #current-answer-content {
       @include textarea-design($width:700px);
       text-align: center;
       .error_messages {

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,8 +15,7 @@ class AnswersController < ApplicationController
       flash[:notice] = "回答が追加されました"
       redirect_to question_path
     else
-      redirect_to question_path(anchor: "current-answer-container"), flash:{error:@answer.errors.full_messages}
-    
+      redirect_to question_path(anchor: "current-answer-content"), flash:{error:@answer.errors.full_messages}
     end
   end  
 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -20,7 +20,7 @@
     <span><%= @answers.count %>件の回答があります</span>
 
     <% if current_user %>
-      <%= link_to "回答する", question_path(anchor: "current-answer-container") %>
+      <%= link_to "回答する", question_path(anchor: "current-answer-content") %>
     <% end %>
   </div>  
 
@@ -118,9 +118,9 @@
 
 
 <% if current_user %>
-  <div id="current-answer-container">
+  <div class="current-answer-container">
     <%= form_with model:@answer, local: true do |form| %>
-      <div class="current-answer-content">       
+      <div id="current-answer-content">       
         <% if flash[:error].present? %>
           <div class="error_messages">
             <ul>


### PR DESCRIPTION
質問詳細ページのanchorの指定先idを"current-answer-container"から"current-answer-content"に変更しました。
# 関連issue
#153 