### PR TITLE
質問詳細ページにおける回答の並び順の変更

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -11,7 +11,7 @@ class Question < ApplicationRecord
   end
 
   def answers
-    return Answer.where(question_id:self.id)
+    return Answer.where(question_id:self.id).order(updated_at: :desc).includes(:interests).sort {|a,b| b.interests.count <=> a.interests.count}
   end
 
   mount_uploader :question_image, ImageUploader


### PR DESCRIPTION
質問詳細ページの回答の並び順を更新日時の新しい順から、"ためになった"が多い順に変更し、"ためになった"の数が同じであれば更新日時が新しい順にしました。
# 関連issue
#155 