### PR TITLE
質問一覧ページで質問、回答をいつ更新したか表示

### DIFF
--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -8,6 +8,7 @@
     <%= image_tag "default.jpg", size: "120x80" %>
   <% end %>
   <%= link_to(question.user.name, user_path(question.user.id)) %>
+  <%= time_ago_in_words(question.updated_at) %>に相談
   <%= link_to(question.question_content, question_path(question.id)) %>
   <% if question.question_image.present? %>
     <%= image_tag question.question_image.url %>
@@ -24,6 +25,7 @@
       <% end %>
 
       <%= link_to(answer.user.name, user_path(answer.user.id)) %>
+      <%= time_ago_in_words(answer.updated_at) %>に回答
 
       <%= answer.answer_content %>
       <% if answer.answer_image.present? %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,3 +14,33 @@ ja:
   errors:
     messages:
       extension_whitelist_error: "の拡張子はjpg、jpeg、gif、pngのみ有効です"
+  datetime:
+    distance_in_words:
+
+      less_than_x_minutes:
+        one:   "1分以内"
+        other: "%{count}分以内"
+      x_minutes:
+        one:   "1分前"
+        other: "%{count}分前"
+      about_x_hours:
+        one:   "1時間前"
+        other: "%{count}時間前"
+      x_days:
+        one:   "1日前"
+        other: "%{count}日前"
+      about_x_months:
+        one:   "1ヶ月前"
+        other: "%{count}ヶ月前"
+      x_months:
+        one:   "1ヶ月前"
+        other: "%{count}ヶ月前"
+      almost_x_years:
+        one:   "１年以内"
+        other: "%{count}年以内"
+      about_x_years:
+        one:   "1年前"
+        other: "%{count}年前"
+      over_x_years:
+        one:   "1年以上前"
+        other: "%{count}年以上前"


### PR DESCRIPTION
質問一覧ページで質問、回答の更新日を"〇〇前に相談"、"〇〇前に回答"のように表示しました。
# 関連issue
#157 