### PR TITLE
ユーザー詳細ページの質問の更新日の表記を変更

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,8 +11,10 @@
       <% end %>
 
       <div class="question_user_name_and_update_at">
-        <li><%= link_to(question.user.name, user_path) %></li>
-        <li><%= question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></li>
+        <ul>
+          <li><%= link_to(question.user.name, user_path) %></li>
+          <li><span><%= time_ago_in_words(question.updated_at) %>に相談</span></li>
+        </ul>
       </div>
     </div>
   

--- a/app/views/users/user_answers.erb
+++ b/app/views/users/user_answers.erb
@@ -10,10 +10,10 @@
       <% end %>
 
       <div class="question_user_name_and_update_at">
-      <ul>
-        <li><%= link_to(answer.question.user.name, user_path(answer.question.user_id)) %></li>
-        <li><%= answer.question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></li>
-      </ul>
+        <ul>
+          <li><%= link_to(answer.question.user.name, user_path(answer.question.user_id)) %></li>
+          <li><span><%= time_ago_in_words(answer.question.updated_at) %>に相談</span></li>
+        </ul>
       </div>
     </div>
 

--- a/app/views/users/user_favorites.erb
+++ b/app/views/users/user_favorites.erb
@@ -12,7 +12,7 @@
       <div class="question_user_name_and_update_at">
         <ul>
           <li><%= link_to(favorite.question.user.name, user_path) %></li>
-          <li><%= favorite.question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></li>
+          <li><span><%= time_ago_in_words(favorite.question.updated_at) %>に相談</span></li>
         </ul>
       </div>
     </div>

--- a/app/views/users/user_interests.erb
+++ b/app/views/users/user_interests.erb
@@ -12,7 +12,7 @@
       <div class="question_user_name_and_update_at">
         <ul>
           <li><%= link_to(interest.answer.question.user.name, user_path(interest.answer.question.user_id)) %></li>
-          <li><%= interest.answer.question.updated_at.strftime("%Y年 %m月 %d日 %H:%M") %></li>
+          <li><span><%= time_ago_in_words(interest.answer.question.updated_at) %>に相談</span></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
ユーザー詳細ページの質問の更新日の表記を"〇年 〇月 〇日 〇:〇"から"〇〇前に相談"に変更しました。
# 関連issue
#181 