### PR TITLE
ヘッダーの入力フォームのデザインが関係ない入力フォームに適用されないよう変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -56,7 +56,7 @@ header {
  background-color: #f390a0;
 }
 
-input {
+.question-search-field input {
   list-style: none;
   float: right;
   font-size: 16px;
@@ -69,7 +69,7 @@ input {
   border-radius: 6px;
 }
 
-input:focus {
+.question-search-field input:focus {
   border: solid 2.5px #313131;
   box-shadow: 0 1px 2px #888888;
   outline: none;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,9 +15,11 @@
     </ul>
   </div>
 
-  <%= form_with url: questions_path, method: :get, local: true do |form| %>
-    <%= form.text_field :search, placeholder:"相談内容で検索" %>    
-  <% end %>
+  <div class="question-search-field">  
+    <%= form_with url: questions_path, method: :get, local: true do |form| %>
+      <%= form.text_field :search, placeholder:"相談内容で検索" %>    
+    <% end %>
+  </div>
 </header>
 
 <div class="header-bottom">


### PR DESCRIPTION
application.cssのヘッダーの入力フォームのデザインが、他のページの入力フォームにも影響を及ぼしているため、ヘッダーの入力フォームのみデザインが適用されるようにしました。
# 関連issue
#189 