### PR TITLE
ログイン前後にヘッダーのデザインが崩れるのを直す

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -46,6 +46,12 @@ header {
   background-color: #f390a0;
 }
 
+
+.header-list {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .header-list li {
   list-style: none;
   float: right;
@@ -57,8 +63,6 @@ header {
 }
 
 .question-search-field input {
-  list-style: none;
-  float: right;
   font-size: 16px;
   background-color: #ffffffa1;
   width: 250px;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,8 +2,14 @@
   <div class="header-logo">
     <%= link_to("Well-child-Space", root_path) %>
   </div>
-  
-  <div class="header-list">  
+
+  <div class="header-list">
+    <div class="question-search-field">  
+      <%= form_with url: questions_path, method: :get, local: true do |form| %>
+        <%= form.text_field :search, placeholder:"相談内容で検索" %>    
+      <% end %>
+    </div>  
+    
     <ul>
       <% if user_signed_in? %>  
         <li><%= link_to("プロフィール", user_path(current_user.id)) %></li>
@@ -13,12 +19,6 @@
       　<li><%= link_to("ログイン", new_user_session_path) %></li>
       <% end %>     
     </ul>
-  </div>
-
-  <div class="question-search-field">  
-    <%= form_with url: questions_path, method: :get, local: true do |form| %>
-      <%= form.text_field :search, placeholder:"相談内容で検索" %>    
-    <% end %>
   </div>
 </header>
 


### PR DESCRIPTION
ログイン前と後でヘッダーのデザインが崩れるのを直しました。
# 関連issue
#193 