### PR TITLE
gitignoreにcoverageディレクトリを追加し、git管理下から除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# Ignore test-related files
+/coverage.data
+/coverage/


### PR DESCRIPTION
.gitignoreにcoverageディレクトリを追加して、git管理下から除外しました。
# 関連issue
#206 