### PR TITLE
CSSで色の指定の仕方を修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -47,7 +47,7 @@ header {
 }
 
 .header-logo a:hover {
-  color: rgb(220 220 220);
+  color: rgb(220, 220, 220);
 }
 
 .header-logo:hover {
@@ -90,7 +90,7 @@ header {
  }
 
  .header-option a:hover {
-  color: rgb(220 220 220);
+  color: rgb(220, 220, 220);
  }
 
 .header-bottom {


### PR DESCRIPTION
CSSで色の指定をrgb(220 220 220)からrgb(220, 220, 220)のようにカンマで区切るよう修正しました。
# 関連issue
#229 